### PR TITLE
Add Spektor CLI and system collector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+build/
+dist/
+*.egg-info/
+.venv/
+.env/
+artifacts/
+debug/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## v0.1.0 (2025-10-03)
+
+* Initial release with Linux collector producing JSON schema v0.1.0.
+* Interactive REPL default command with Ollama-backed overview, section, and query tools.
+* Debug artifacts for collector and LLM interactions, including raw command logs and JSONL streams.
+* Packaging metadata, usage documentation, and parser unit tests.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: lint test package
+
+lint:
+	python -m compileall spektor
+
+test:
+	python -m unittest discover -s tests -v
+
+package:
+	python -m build

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Homedoc Spektor
+# HomeDoc Spektor
 
-Homedoc Spektor captures Linux system inventory data and generates reports with
+HomeDoc Spektor captures Linux system inventory data and generates reports with
 local Ollama models. The tool gathers CPU, memory, storage, firmware, and
 software facts as structured JSON then asks an LLM for summaries, section deep
 dives, or answers to ad-hoc questions.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
-# homedoc-spektor
-HomeDoc Spektor part of the HomeDoc utility family, turns system info into parseable json und feeds output to local LLM.
+# Homedoc Spektor
+
+Homedoc Spektor captures Linux system inventory data and generates reports with
+local Ollama models. The tool gathers CPU, memory, storage, firmware, and
+software facts as structured JSON then asks an LLM for summaries, section deep
+dives, or answers to ad-hoc questions.
+
+## Quick start
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e .
+
+# Collect data into system.json
+spektor collect --output system.json
+
+# Generate an overview report using the default model
+spektor report --input system.json --overview
+
+# Launch the interactive REPL (default command)
+spektor
+```
+
+See [USAGE.md](USAGE.md) for detailed CLI and REPL instructions.

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,0 +1,109 @@
+# Usage
+
+Homedoc Spektor ships with both non-interactive commands and an interactive
+shell. Install the package (`pip install -e .`) or invoke via `python
+spektor-cli.py` from the repository root.
+
+## Interactive shell
+
+Running `spektor` with no arguments launches the REPL. The startup flow prompts
+for the Ollama server URL and model. Defaults are:
+
+- server: `http://localhost:11434`
+- model: `gemma3:12b`
+
+Available model shortcuts:
+
+1. `gemma3:12b` (default)
+2. `qwen3:14b` (thinking model)
+3. `mistral:7b` (~4 GB)
+4. `other` (enter a custom model name)
+
+### REPL commands
+
+```
+collect [--debug] [--raw-dir DIR] [--timeout N]
+load <path>
+save <path>
+overview
+section <name[,name]>
+ask <question>
+show [json.path]
+quit
+```
+
+Toggles are available for LLM thinking controls:
+
+```
+:show-thinking on|off
+:save-thinking on|off
+```
+
+After each action the shell prints the equivalent CLI invocation to help users
+transition to scripts and automation.
+
+## CLI commands
+
+### `spektor collect`
+
+```
+spektor collect --output system.json [--debug] [--raw-dir DIR] [--timeout N]
+```
+
+Collects system facts on Linux hosts. When `--debug` is supplied the collector
+stores raw command output inside an `artifacts/` directory (or the provided
+`--raw-dir`). The resulting JSON always includes the schema version and schema
+validation issues when present.
+
+### `spektor report`
+
+```
+spektor report --input system.json [--overview] [--section NAME ...] \
+  [--json-only] [--model MODEL] [--server URL] [--system-prompt PROMPT] \
+  [--show-thinking] [--save-thinking] [--debug]
+```
+
+Reads a saved JSON document and uses the Ollama model to produce human-friendly
+summaries. `--json-only` skips the LLM call and prints the document. When
+`--system-prompt` is provided the value is treated as a file path if it exists,
+otherwise it is interpreted as inline prompt text.
+
+### `spektor query`
+
+```
+spektor query --input system.json "Do we have an NVIDIA GPU?" \
+  [--json-only] [--model MODEL] [--server URL] [--system-prompt PROMPT] \
+  [--show-thinking] [--save-thinking] [--debug]
+```
+
+Answers ad-hoc questions strictly from the JSON document. If the requested data
+is missing the response lists commands to run in order to collect it.
+
+### `spektor interactive`
+
+```
+spektor interactive [--input system.json] [--model MODEL] [--server URL]
+```
+
+Starts the REPL with optional defaults. If `--input` is provided the JSON file is
+loaded automatically after startup.
+
+## Environment variables
+
+- `SPEKTOR_EXTRAS` — comma-separated list controlling additional collection
+  steps. Recognised values: `docker`, `systemd`, `kvm`.
+- `SPEKTOR_DEBUG_LLM` — when set to `1`, enables capture of Ollama JSONL streams
+  and metadata even without `--debug`.
+- `SPEKTOR_THINKING` — when set to `show` includes `<thinking>` blocks in
+  console output. When set to `save` always stores raw responses (with thinking)
+  under `debug/`.
+
+## Debug artifacts
+
+- Collector debug artifacts live under `artifacts/` (or the directory supplied
+  via `--raw-dir`). Each command logs its arguments, return code, stdout, and
+  stderr as JSON for reproducibility.
+- LLM debug artifacts live under `debug/`. Streamed responses are stored as
+  `ollama_<timestamp>_<session>.jsonl` with matching metadata in
+  `ollama_meta.json`. When thinking output capture is enabled raw responses are
+  saved with the pattern `YYYYmmdd_HHMMSS_model_task_host_pid.raw.txt`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "homedoc-spektor"
+version = "0.1.0"
+description = "Collect Linux system inventories and summarise them with local LLMs"
+readme = "README.md"
+requires-python = ">=3.10"
+license = {text = "GPL-3.0-or-later"}
+authors = [
+  {name = "HomeDoc Contributors"}
+]
+classifiers = [
+  "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Environment :: Console",
+  "Operating System :: POSIX :: Linux",
+]
+dependencies = []
+
+[project.scripts]
+spektor = "spektor-cli:main"
+
+[tool.setuptools]
+packages = ["spektor"]
+include-package-data = false

--- a/spektor-cli.py
+++ b/spektor-cli.py
@@ -1,0 +1,186 @@
+"""Command line interface for the Spektor toolkit."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Any, Dict, List
+
+from spektor.interactive import main as interactive_main
+from spektor.llm import DEFAULT_BASE_URL, DEFAULT_MODEL, OllamaClient
+from spektor.reporting import answer_query, overview, per_section
+from spektor.sysprobe import collect as collect_probe
+from spektor.util import safe_json_dump
+
+
+def _load_document(path: str) -> Dict[str, Any]:
+    with open(path, "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _save_document(path: str, document: Dict[str, Any]) -> None:
+    safe_json_dump(document, path)
+
+
+def _resolve_system_prompt(value: str | None) -> str:
+    if not value:
+        return ""
+    if os.path.exists(value):
+        with open(value, "r", encoding="utf-8") as fh:
+            return fh.read()
+    return value
+
+
+def _create_client(args: argparse.Namespace) -> OllamaClient:
+    return OllamaClient(
+        base_url=args.server or DEFAULT_BASE_URL,
+        model=args.model or DEFAULT_MODEL,
+        show_thinking=args.show_thinking,
+        save_thinking=args.save_thinking,
+        debug=args.debug,
+    )
+
+
+def handle_collect(args: argparse.Namespace) -> int:
+    document = collect_probe(debug=args.debug, raw_dir=args.raw_dir, timeout=args.timeout)
+    if args.output:
+        _save_document(args.output, document)
+    else:
+        print(json.dumps(document, ensure_ascii=False, indent=2))
+    return 0
+
+
+def handle_report(args: argparse.Namespace) -> int:
+    document = _load_document(args.input)
+    if args.json_only:
+        print(json.dumps(document, ensure_ascii=False, indent=2))
+        return 0
+    client = _create_client(args)
+    system_prompt = _resolve_system_prompt(args.system_prompt)
+    responses: List[str] = []
+    if args.overview:
+        responses.append(
+            overview(
+                document,
+                client,
+                system_override=system_prompt or None,
+                show_thinking=args.show_thinking,
+                save_thinking=args.save_thinking,
+            ).text
+        )
+    if args.section:
+        responses.append(
+            per_section(
+                document,
+                args.section,
+                client,
+                system_override=system_prompt or None,
+                show_thinking=args.show_thinking,
+                save_thinking=args.save_thinking,
+            ).text
+        )
+    if not responses:
+        responses.append(
+            overview(
+                document,
+                client,
+                system_override=system_prompt or None,
+                show_thinking=args.show_thinking,
+                save_thinking=args.save_thinking,
+            ).text
+        )
+    print("\n\n".join(responses))
+    return 0
+
+
+def handle_query(args: argparse.Namespace) -> int:
+    document = _load_document(args.input)
+    if args.json_only:
+        print(json.dumps(document, ensure_ascii=False, indent=2))
+        return 0
+    client = _create_client(args)
+    question = " ".join(args.question).strip()
+    if not question:
+        print("A question is required for the query command.")
+        return 1
+    response = answer_query(
+        document,
+        question,
+        client,
+        system_override=_resolve_system_prompt(args.system_prompt) or None,
+        show_thinking=args.show_thinking,
+        save_thinking=args.save_thinking,
+    )
+    print(response.text)
+    return 0
+
+
+def handle_interactive(args: argparse.Namespace) -> int:
+    interactive_main(input_path=args.input, model=args.model, server=args.server)
+    return 0
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="spektor")
+    subparsers = parser.add_subparsers(dest="command")
+
+    collect_p = subparsers.add_parser("collect", help="Collect system information")
+    collect_p.add_argument("--output", help="Destination file for JSON output")
+    collect_p.add_argument("--debug", action="store_true", help="Enable debug artifact capture")
+    collect_p.add_argument("--raw-dir", help="Directory for raw command output")
+    collect_p.add_argument("--timeout", type=int, default=5, help="Command timeout seconds")
+    collect_p.set_defaults(func=handle_collect)
+
+    common_llm = {
+        "--model": {"default": DEFAULT_MODEL, "help": "Ollama model name"},
+        "--server": {"default": DEFAULT_BASE_URL, "help": "Ollama server URL"},
+        "--show-thinking": {"action": "store_true", "help": "Display <thinking> blocks"},
+        "--save-thinking": {"action": "store_true", "help": "Persist raw responses"},
+        "--debug": {"action": "store_true", "help": "Enable debug capture"},
+    }
+
+    report_p = subparsers.add_parser("report", help="Generate LLM assisted report")
+    report_p.add_argument("--input", required=True, help="Path to JSON document")
+    report_p.add_argument("--overview", action="store_true", help="Include system overview")
+    report_p.add_argument("--section", action="append", help="Analyse named section", metavar="NAME")
+    report_p.add_argument("--json-only", action="store_true", help="Print JSON and skip LLM")
+    report_p.add_argument("--system-prompt", help="Override system prompt (path or text)")
+    for flag, options in common_llm.items():
+        report_p.add_argument(flag, **options)
+    report_p.set_defaults(func=handle_report)
+
+    query_p = subparsers.add_parser("query", help="Answer ad-hoc question")
+    query_p.add_argument("--input", required=True, help="Path to JSON document")
+    query_p.add_argument("--json-only", action="store_true")
+    query_p.add_argument("--system-prompt", help="Override system prompt (path or text)")
+    for flag, options in common_llm.items():
+        query_p.add_argument(flag, **options)
+    query_p.add_argument("question", nargs=argparse.REMAINDER, help="Question to answer")
+    query_p.set_defaults(func=handle_query)
+
+    interactive_p = subparsers.add_parser("interactive", help="Start interactive shell")
+    interactive_p.add_argument("--input", help="Load JSON document on start")
+    interactive_p.add_argument("--model", default=DEFAULT_MODEL)
+    interactive_p.add_argument("--server", default=DEFAULT_BASE_URL)
+    interactive_p.set_defaults(func=handle_interactive)
+
+    return parser
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = create_parser()
+    args = parser.parse_args(argv)
+    if not args.command:
+        interactive_main()
+        return 0
+    func = getattr(args, "func", None)
+    if func is None:
+        parser.print_help()
+        return 1
+    return func(args)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    raise SystemExit(main())

--- a/spektor/__init__.py
+++ b/spektor/__init__.py
@@ -1,0 +1,5 @@
+"""Spektor package initialization."""
+
+from .version import __version__
+
+__all__ = ["__version__"]

--- a/spektor/interactive.py
+++ b/spektor/interactive.py
@@ -1,0 +1,278 @@
+"""Interactive REPL for Spektor."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+from typing import Any, Dict, List, Optional
+
+from .llm import OllamaClient
+from .reporting import answer_query, overview, per_section
+from .sysprobe import collect as collect_probe
+from .util import safe_json_dump
+
+DEFAULT_SERVER = "http://localhost:11434"
+DEFAULT_MODEL = "gemma3:12b"
+MODEL_CHOICES = [
+    ("gemma3:12b", "default"),
+    ("qwen3:14b", "thinking model"),
+    ("mistral:7b", "~4 GB"),
+    ("other", "custom"),
+]
+
+
+class InteractiveShell:
+    def __init__(
+        self,
+        *,
+        initial_document: Optional[Dict[str, Any]] = None,
+        default_model: str = DEFAULT_MODEL,
+        default_server: str = DEFAULT_SERVER,
+    ) -> None:
+        self.server = default_server
+        self.model = default_model
+        self.client: Optional[OllamaClient] = None
+        self.document: Optional[Dict[str, Any]] = initial_document
+        self.show_thinking = False
+        self.save_thinking = False
+
+    def start(self) -> None:
+        print("Spektor interactive shell. Type 'help' for commands.")
+        self._configure_llm()
+        self.loop()
+
+    def _configure_llm(self) -> None:
+        server = input(f"Ollama server [{DEFAULT_SERVER}]: ").strip()
+        if server:
+            self.server = server
+        print("Available models:")
+        for idx, (model, desc) in enumerate(MODEL_CHOICES, 1):
+            print(f"  {idx}. {model} ({desc})")
+        selection = input(f"Select model [1]: ").strip() or "1"
+        try:
+            choice_idx = int(selection) - 1
+            model_choice = MODEL_CHOICES[choice_idx][0]
+        except (ValueError, IndexError):
+            model_choice = DEFAULT_MODEL
+        if model_choice == "other":
+            custom = input("Enter model name: ").strip()
+            if custom:
+                self.model = custom
+        else:
+            self.model = model_choice
+        self.client = OllamaClient(base_url=self.server, model=self.model)
+        print(f"Using {self.model} at {self.server}")
+
+    def loop(self) -> None:
+        while True:
+            try:
+                raw = input("spektor> ").strip()
+            except (EOFError, KeyboardInterrupt):
+                print()
+                break
+            if not raw:
+                continue
+            if raw in {"quit", "exit"}:
+                break
+            if raw == "help":
+                self._print_help()
+                continue
+            if raw.startswith(":"):
+                self._handle_toggle(raw)
+                continue
+            self._dispatch(raw)
+
+    def _print_help(self) -> None:
+        print("Available commands:")
+        print("  collect [--debug] [--raw-dir DIR] [--timeout N]")
+        print("  load <path>")
+        print("  save <path>")
+        print("  overview")
+        print("  section <name[,name]>\n  ask <question>")
+        print("  show [json.path]")
+        print("  quit")
+        print("  :show-thinking on|off  :save-thinking on|off")
+
+    def _handle_toggle(self, raw: str) -> None:
+        parts = raw.split()
+        if parts[0] == ":show-thinking" and len(parts) > 1:
+            self.show_thinking = parts[1].lower() == "on"
+            print(f"Show thinking: {self.show_thinking}")
+        elif parts[0] == ":save-thinking" and len(parts) > 1:
+            self.save_thinking = parts[1].lower() == "on"
+            print(f"Save thinking: {self.save_thinking}")
+        else:
+            print("Unknown toggle")
+
+    def _ensure_doc(self) -> bool:
+        if self.document is None:
+            print("No document loaded. Run 'collect' or 'load <path>'.")
+            return False
+        return True
+
+    def _dispatch(self, raw: str) -> None:
+        parts = shlex.split(raw)
+        if not parts:
+            return
+        cmd, *args = parts
+        if cmd == "collect":
+            self._cmd_collect(args)
+        elif cmd == "load":
+            self._cmd_load(args)
+        elif cmd == "save":
+            self._cmd_save(args)
+        elif cmd == "overview":
+            self._cmd_overview()
+        elif cmd == "section":
+            self._cmd_section(args)
+        elif cmd == "ask":
+            self._cmd_ask(args)
+        elif cmd == "show":
+            self._cmd_show(args)
+        else:
+            print(f"Unknown command: {cmd}")
+
+    def _cmd_collect(self, args: List[str]) -> None:
+        parser = argparse.ArgumentParser(prog="collect", add_help=False)
+        parser.add_argument("--debug", action="store_true")
+        parser.add_argument("--raw-dir")
+        parser.add_argument("--timeout", type=int, default=5)
+        try:
+            ns = parser.parse_args(args)
+        except SystemExit:
+            return
+        self.document = collect_probe(debug=ns.debug, raw_dir=ns.raw_dir, timeout=ns.timeout)
+        print("Collection complete.")
+        self._print_equivalent(
+            "collect",
+            [
+                f"--output <file>",
+                "--debug" if ns.debug else None,
+                f"--raw-dir {ns.raw_dir}" if ns.raw_dir else None,
+                f"--timeout {ns.timeout}" if ns.timeout else None,
+            ],
+        )
+
+    def _cmd_load(self, args: List[str]) -> None:
+        if not args:
+            print("Usage: load <path>")
+            return
+        path = args[0]
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                self.document = json.load(fh)
+        except OSError as exc:
+            print(f"Failed to load {path}: {exc}")
+            return
+        print(f"Loaded {path}")
+        self._print_equivalent("collect", [f"--output {path}"])
+
+    def _cmd_save(self, args: List[str]) -> None:
+        if not self._ensure_doc():
+            return
+        if not args:
+            print("Usage: save <path>")
+            return
+        path = args[0]
+        safe_json_dump(self.document, path)
+        print(f"Saved {path}")
+        self._print_equivalent("collect", [f"--output {path}"])
+
+    def _cmd_overview(self) -> None:
+        if not self._ensure_doc() or self.client is None:
+            return
+        response = overview(
+            self.document,
+            self.client,
+            show_thinking=self.show_thinking,
+            save_thinking=self.save_thinking,
+        )
+        print(response.text)
+        self._print_equivalent("report", ["--input <file>", "--overview"])
+
+    def _cmd_section(self, args: List[str]) -> None:
+        if not self._ensure_doc() or self.client is None:
+            return
+        if not args:
+            print("Usage: section <name[,name]>")
+            return
+        sections = [part.strip() for part in args[0].split(",") if part.strip()]
+        response = per_section(
+            self.document,
+            sections,
+            self.client,
+            show_thinking=self.show_thinking,
+            save_thinking=self.save_thinking,
+        )
+        print(response.text)
+        args = ["--input <file>"]
+        for section in sections:
+            args.append(f"--section {section}")
+        self._print_equivalent("report", args)
+
+    def _cmd_ask(self, args: List[str]) -> None:
+        if not self._ensure_doc() or self.client is None:
+            return
+        if not args:
+            print("Usage: ask <question>")
+            return
+        question = " ".join(args)
+        response = answer_query(
+            self.document,
+            question,
+            self.client,
+            show_thinking=self.show_thinking,
+            save_thinking=self.save_thinking,
+        )
+        print(response.text)
+        self._print_equivalent("query", ["--input <file>", json.dumps(question)])
+
+    def _cmd_show(self, args: List[str]) -> None:
+        if not self._ensure_doc():
+            return
+        if not args:
+            print(json.dumps(self.document, indent=2, ensure_ascii=False))
+            return
+        path = args[0]
+        value = self.document
+        for part in path.split("."):
+            if isinstance(value, dict):
+                value = value.get(part)
+            elif isinstance(value, list):
+                try:
+                    idx = int(part)
+                    value = value[idx]
+                except (ValueError, IndexError):
+                    value = None
+                    break
+            else:
+                value = None
+                break
+        print(json.dumps(value, indent=2, ensure_ascii=False))
+
+    def _print_equivalent(self, subcommand: str, args: List[Optional[str]]) -> None:
+        filtered = [arg for arg in args if arg]
+        pieces = ["spektor", subcommand] + filtered
+        print("# CLI equivalent: " + " ".join(pieces))
+
+
+def main(
+    *,
+    input_path: str | None = None,
+    model: str = DEFAULT_MODEL,
+    server: str = DEFAULT_SERVER,
+) -> None:
+    document = None
+    if input_path:
+        try:
+            with open(input_path, "r", encoding="utf-8") as fh:
+                document = json.load(fh)
+        except OSError as exc:
+            print(f"Failed to load {input_path}: {exc}")
+    shell = InteractiveShell(initial_document=document, default_model=model, default_server=server)
+    shell.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/spektor/llm.py
+++ b/spektor/llm.py
@@ -1,0 +1,153 @@
+"""Ollama client wrapper with thinking controls and debug capture."""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import re
+import socket
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from .util import now_iso, safe_json_dump, sha256_text
+
+DEFAULT_MODEL = "gemma3:12b"
+DEFAULT_BASE_URL = "http://localhost:11434"
+DEBUG_DIR = pathlib.Path("debug")
+
+
+@dataclass
+class OllamaResponse:
+    text: str
+    raw_text: str
+    meta: Dict[str, Any]
+
+
+def _strip_thinking(text: str) -> str:
+    pattern = re.compile(r"<thinking>.*?</thinking>", re.DOTALL | re.IGNORECASE)
+    return pattern.sub("", text)
+
+
+def _sanitize(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9._-]", "-", value)
+
+
+class OllamaClient:
+    """Minimal Ollama HTTP client."""
+
+    def __init__(
+        self,
+        base_url: str = DEFAULT_BASE_URL,
+        model: str = DEFAULT_MODEL,
+        *,
+        show_thinking: Optional[bool] = None,
+        save_thinking: Optional[bool] = None,
+        debug: bool = False,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.model = model
+        self.debug = debug or os.environ.get("SPEKTOR_DEBUG_LLM") == "1"
+        thinking_env = os.environ.get("SPEKTOR_THINKING", "").strip().lower()
+        self.show_thinking = show_thinking if show_thinking is not None else thinking_env == "show"
+        self.save_thinking = save_thinking if save_thinking is not None else thinking_env == "save"
+        self.session_id = _sanitize(os.urandom(4).hex())
+        if self.save_thinking or self.debug:
+            DEBUG_DIR.mkdir(exist_ok=True)
+
+    def generate(
+        self,
+        prompt: str,
+        *,
+        system: str = "",
+        task: str = "query",
+        show_thinking: Optional[bool] = None,
+        save_thinking: Optional[bool] = None,
+    ) -> OllamaResponse:
+        """Generate a completion using the configured Ollama endpoint."""
+
+        show_think = self.show_thinking if show_thinking is None else show_thinking
+        save_think = self.save_thinking if save_thinking is None else save_thinking
+
+        url = f"{self.base_url}/api/generate"
+        payload = {
+            "model": self.model,
+            "prompt": prompt,
+            "system": system,
+            "stream": True,
+        }
+        data = json.dumps(payload).encode("utf-8")
+        request = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"})
+
+        start_time = time.time()
+        raw_lines: list[str] = []
+        response_text_parts: list[str] = []
+        http_status: Optional[int] = None
+        meta_chunk: Dict[str, Any] = {}
+
+        try:
+            with urllib.request.urlopen(request) as resp:
+                http_status = resp.status
+                for raw in resp:
+                    decoded = raw.decode("utf-8").strip()
+                    if not decoded:
+                        continue
+                    raw_lines.append(decoded)
+                    try:
+                        chunk = json.loads(decoded)
+                    except json.JSONDecodeError:
+                        continue
+                    if chunk.get("done"):
+                        meta_chunk = chunk
+                        break
+                    part = chunk.get("response", "")
+                    response_text_parts.append(part)
+        except urllib.error.HTTPError as exc:  # pragma: no cover - depends on runtime server
+            http_status = exc.code
+            error_text = exc.read().decode("utf-8", errors="replace")
+            raw_lines.append(error_text)
+            response_text_parts.append(error_text)
+        except urllib.error.URLError as exc:  # pragma: no cover - depends on runtime server
+            error_text = str(exc)
+            raw_lines.append(error_text)
+            response_text_parts.append(error_text)
+
+        duration = time.time() - start_time
+        raw_text = "".join(response_text_parts)
+        display_text = raw_text if show_think else _strip_thinking(raw_text)
+
+        timestamp = time.strftime("%Y%m%d_%H%M%S")
+        model_clean = _sanitize(self.model.replace(":", "-"))
+        host = _sanitize(socket.gethostname())
+        pid = os.getpid()
+
+        debug_meta = {
+            "model": self.model,
+            "system_prompt_sha256": sha256_text(system or ""),
+            "prompt_sha256": sha256_text(prompt),
+            "http_status": http_status,
+            "timings": {
+                "started_at": now_iso(),
+                "duration_seconds": duration,
+            },
+            "meta_chunk": meta_chunk,
+        }
+
+        if self.debug:
+            DEBUG_DIR.mkdir(exist_ok=True)
+            jsonl_path = DEBUG_DIR / f"ollama_{timestamp}_{self.session_id}.jsonl"
+            with jsonl_path.open("w", encoding="utf-8") as fh:
+                fh.write("\n".join(raw_lines))
+                fh.write("\n")
+            safe_json_dump(debug_meta, DEBUG_DIR / "ollama_meta.json")
+
+        if save_think or self.debug:
+            DEBUG_DIR.mkdir(exist_ok=True)
+            raw_filename = DEBUG_DIR / f"{timestamp}_{model_clean}_{task}_{host}_{pid}.raw.txt"
+            with raw_filename.open("w", encoding="utf-8") as fh:
+                fh.write(raw_text)
+
+        return OllamaResponse(text=display_text.strip(), raw_text=raw_text.strip(), meta=debug_meta)

--- a/spektor/reporting.py
+++ b/spektor/reporting.py
@@ -1,0 +1,121 @@
+"""High level reporting utilities backed by the Ollama client."""
+
+from __future__ import annotations
+
+import copy
+import json
+from typing import Iterable
+
+from .llm import OllamaClient
+
+_SYSTEM = (
+    "Use ONLY provided JSON. If missing, state what to run to obtain it. "
+    "Bullet points. Reference JSON paths."
+)
+
+
+def _compact(doc: dict, max_pkgs: int = 100) -> dict:
+    compacted = copy.deepcopy(doc)
+    try:
+        packages = compacted["software"]["packages"]
+        items = packages.get("items", [])
+        if isinstance(items, list) and len(items) > max_pkgs:
+            remaining = len(items) - max_pkgs
+            packages["items"] = items[:max_pkgs] + [f"(+{remaining} more)"]
+            packages["truncated"] = True
+    except KeyError:
+        pass
+    return compacted
+
+
+def _render_json(doc: dict) -> str:
+    return json.dumps(doc, ensure_ascii=False, indent=2)
+
+
+def _call_llm(
+    client: OllamaClient,
+    prompt: str,
+    task: str,
+    *,
+    system_override: str | None = None,
+    show_thinking: bool | None = None,
+    save_thinking: bool | None = None,
+):
+    system_prompt = system_override if system_override is not None else _SYSTEM
+    return client.generate(
+        prompt,
+        system=system_prompt,
+        task=task,
+        show_thinking=show_thinking,
+        save_thinking=save_thinking,
+    )
+
+
+def overview(
+    doc: dict,
+    client: OllamaClient,
+    *,
+    system_override: str | None = None,
+    show_thinking: bool | None = None,
+    save_thinking: bool | None = None,
+):
+    payload = _render_json(_compact(doc))
+    prompt = (
+        "Summarise hardware and software capabilities with constraints. "
+        "Call out virtualization readiness, GPU status, storage, networking."
+        "\n" + payload
+    )
+    return _call_llm(
+        client,
+        prompt,
+        task="overview",
+        system_override=system_override,
+        show_thinking=show_thinking,
+        save_thinking=save_thinking,
+    )
+
+
+def per_section(
+    doc: dict,
+    sections: Iterable[str],
+    client: OllamaClient,
+    *,
+    system_override: str | None = None,
+    show_thinking: bool | None = None,
+    save_thinking: bool | None = None,
+):
+    payload = _render_json(_compact(doc))
+    section_list = ", ".join(sections) if sections else "(all)"
+    prompt = (
+        f"Provide actionable checks for sections: {section_list}. "
+        "Highlight missing data and remediation commands.\n" + payload
+    )
+    return _call_llm(
+        client,
+        prompt,
+        task="section",
+        system_override=system_override,
+        show_thinking=show_thinking,
+        save_thinking=save_thinking,
+    )
+
+
+def answer_query(
+    doc: dict,
+    question: str,
+    client: OllamaClient,
+    *,
+    system_override: str | None = None,
+    show_thinking: bool | None = None,
+    save_thinking: bool | None = None,
+):
+    payload = _render_json(_compact(doc))
+    prompt = f"Question: {question}\nAnswer strictly from JSON.\n{payload}"
+    return _call_llm(
+        client,
+        prompt,
+        task="query",
+        system_override=system_override,
+        show_thinking=show_thinking,
+        save_thinking=save_thinking,
+    )

--- a/spektor/schema.py
+++ b/spektor/schema.py
@@ -1,0 +1,197 @@
+"""JSON schema helpers for system inventory documents."""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Dict, List, Tuple
+
+from .version import __version__
+
+SCHEMA_VERSION = "0.1.0"
+
+BASE_DOC: Dict[str, Any] = {
+    "meta": {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": None,
+        "host": {
+            "hostname": None,
+            "os": {
+                "name": None,
+                "version": None,
+                "id": None,
+                "pretty_name": None,
+                "kernel": None,
+                "architecture": None,
+            },
+        },
+        "collector": {
+            "tool": "spektor",
+            "version": __version__,
+        },
+    },
+    "cpu": {
+        "model": None,
+        "vendor": None,
+        "sockets": None,
+        "cores": None,
+        "threads_per_core": None,
+        "logical_processors": None,
+        "flags": [],
+    },
+    "memory": {
+        "total_bytes": None,
+        "swap_bytes": None,
+        "modules": [],
+    },
+    "motherboard": {
+        "vendor": None,
+        "product": None,
+        "serial": None,
+    },
+    "firmware": {
+        "bios_vendor": None,
+        "bios_version": None,
+        "bios_date": None,
+        "tpm_present": None,
+        "secure_boot": "unknown",
+    },
+    "gpu": [],
+    "storage": [],
+    "network": [],
+    "slots": {
+        "pcie": [],
+    },
+    "buses": {
+        "pci": [],
+        "usb": [],
+    },
+    "software": {
+        "init": None,
+        "packages": {
+            "manager": None,
+            "items": [],
+            "truncated": False,
+        },
+        "runtimes": {},
+        "extras": {},
+    },
+    "debug": {},
+}
+
+
+REQUIRED_TOP_LEVEL = {
+    "meta": dict,
+    "cpu": dict,
+    "memory": dict,
+    "motherboard": dict,
+    "firmware": dict,
+    "gpu": list,
+    "storage": list,
+    "network": list,
+    "slots": dict,
+    "buses": dict,
+    "software": dict,
+}
+
+
+def new_document() -> Dict[str, Any]:
+    """Return a deep copy of :data:`BASE_DOC`."""
+
+    return copy.deepcopy(BASE_DOC)
+
+
+def _require_keys(data: Dict[str, Any], keys: Dict[str, type], prefix: str, errors: List[str]) -> None:
+    for key, expected in keys.items():
+        if key not in data:
+            errors.append(f"Missing key: {prefix}{key}")
+            continue
+        if expected is not None and not isinstance(data[key], expected):
+            errors.append(
+                f"Incorrect type for {prefix}{key}: expected {expected.__name__}, got {type(data[key]).__name__}"
+            )
+
+
+META_REQUIRED = {
+    "schema_version": str,
+    "host": dict,
+}
+
+OS_REQUIRED = {
+    "name": (str, type(None)),
+    "version": (str, type(None)),
+    "id": (str, type(None)),
+    "pretty_name": (str, type(None)),
+    "kernel": (str, type(None)),
+    "architecture": (str, type(None)),
+}
+
+
+def validate(doc: Dict[str, Any]) -> Tuple[bool, List[str]]:
+    """Validate *doc* returning ``(is_valid, errors)``."""
+
+    errors: List[str] = []
+    if not isinstance(doc, dict):
+        return False, ["Document must be a mapping"]
+
+    _require_keys(doc, REQUIRED_TOP_LEVEL, "", errors)
+
+    meta = doc.get("meta", {})
+    if not isinstance(meta, dict):
+        errors.append("meta must be a mapping")
+    else:
+        for key, expected in META_REQUIRED.items():
+            if key not in meta:
+                errors.append(f"Missing key: meta.{key}")
+                continue
+            if not isinstance(meta[key], expected if isinstance(expected, type) else expected):
+                errors.append(f"Invalid type for meta.{key}")
+        host = meta.get("host", {})
+        if isinstance(host, dict):
+            hostname = host.get("hostname")
+            if hostname is not None and not isinstance(hostname, str):
+                errors.append("meta.host.hostname must be a string or null")
+            os_data = host.get("os", {})
+            if isinstance(os_data, dict):
+                for field, exp in OS_REQUIRED.items():
+                    value = os_data.get(field)
+                    if value is not None and not isinstance(value, exp[0]):
+                        errors.append(f"meta.host.os.{field} must be a string or null")
+            else:
+                errors.append("meta.host.os must be a mapping")
+        else:
+            errors.append("meta.host must be a mapping")
+
+    schema_version = meta.get("schema_version") if isinstance(meta, dict) else None
+    if schema_version and schema_version != SCHEMA_VERSION:
+        errors.append(
+            f"Unsupported schema version: {schema_version} (expected {SCHEMA_VERSION})"
+        )
+
+    for section in ("cpu", "memory", "motherboard", "firmware", "software"):
+        value = doc.get(section)
+        if value is not None and not isinstance(value, dict):
+            errors.append(f"{section} must be a mapping")
+
+    for section in ("gpu", "storage", "network"):
+        value = doc.get(section)
+        if value is not None and not isinstance(value, list):
+            errors.append(f"{section} must be a list")
+
+    slots = doc.get("slots")
+    if isinstance(slots, dict):
+        pcie = slots.get("pcie")
+        if pcie is not None and not isinstance(pcie, list):
+            errors.append("slots.pcie must be a list")
+    else:
+        errors.append("slots must be a mapping")
+
+    buses = doc.get("buses")
+    if isinstance(buses, dict):
+        for key in ("pci", "usb"):
+            value = buses.get(key)
+            if value is not None and not isinstance(value, list):
+                errors.append(f"buses.{key} must be a list")
+    else:
+        errors.append("buses must be a mapping")
+
+    return len(errors) == 0, errors

--- a/spektor/sysprobe.py
+++ b/spektor/sysprobe.py
@@ -1,0 +1,522 @@
+"""System probing utilities for Linux hosts."""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import re
+import shlex
+import socket
+from typing import Any, Dict, Iterable, List, Optional
+
+from . import schema
+from .util import now_iso, run_cmd, safe_json_dump, which
+
+RAW_DIR_NAME = "artifacts"
+
+
+class Collector:
+    """Helper object to orchestrate command execution and parsing."""
+
+    def __init__(self, debug: bool, raw_dir: str | None, timeout: int | None) -> None:
+        self.debug = debug
+        self.timeout = timeout
+        self.raw_dir = pathlib.Path(raw_dir or RAW_DIR_NAME)
+        self.raw_dir_path: Optional[pathlib.Path] = None
+        if self.debug:
+            self.raw_dir_path = self.raw_dir.resolve()
+            self.raw_dir_path.mkdir(parents=True, exist_ok=True)
+
+    def run(self, name: str, argv: Iterable[str]) -> tuple[int, str, str]:
+        rc, out, err = run_cmd(list(argv), timeout=self.timeout)
+        if self.debug and self.raw_dir_path is not None:
+            base = self.raw_dir_path / f"{name}.log"
+            safe_json_dump(
+                {
+                    "argv": list(argv),
+                    "returncode": rc,
+                    "stdout": out,
+                    "stderr": err,
+                },
+                base,
+            )
+        return rc, out, err
+
+
+def _parse_os_release(path: str = "/etc/os-release") -> Dict[str, str | None]:
+    data: Dict[str, str | None] = {
+        "name": None,
+        "version": None,
+        "id": None,
+        "pretty_name": None,
+    }
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, value = line.split("=", 1)
+                value = value.strip().strip('"')
+                key = key.lower()
+                if key == "name":
+                    data["name"] = value
+                elif key == "version" or key == "version_id":
+                    if not data["version"]:
+                        data["version"] = value
+                elif key == "id":
+                    data["id"] = value
+                elif key == "pretty_name":
+                    data["pretty_name"] = value
+    except OSError:
+        pass
+    return data
+
+
+def _parse_lscpu(output: str) -> Dict[str, Any]:
+    result: Dict[str, Any] = {}
+    try:
+        payload = json.loads(output)
+        for entry in payload.get("lscpu", []):
+            field = entry.get("field", "").strip().strip(":")
+            data = entry.get("data")
+            if field:
+                result[field] = data
+    except json.JSONDecodeError:
+        pass
+    return result
+
+
+def _parse_cpuinfo(output: str) -> Dict[str, Any]:
+    info: Dict[str, Any] = {}
+    if not output:
+        return info
+    processors = [block for block in output.strip().split("\n\n") if block.strip()]
+    if processors:
+        first = processors[0]
+        for line in first.splitlines():
+            if ":" not in line:
+                continue
+            key, value = [part.strip() for part in line.split(":", 1)]
+            info[key] = value
+    info["processor_count"] = len(processors)
+    return info
+
+
+def _parse_meminfo(output: str) -> Dict[str, int]:
+    result: Dict[str, int] = {}
+    pattern = re.compile(r"^(\w+):\s+(\d+)\s*(\w+)?")
+    for line in output.splitlines():
+        match = pattern.match(line)
+        if not match:
+            continue
+        key, value, unit = match.groups()
+        value = int(value)
+        unit = (unit or "B").upper()
+        if unit == "KB":
+            value *= 1024
+        elif unit == "MB":
+            value *= 1024 * 1024
+        elif unit == "GB":
+            value *= 1024 * 1024 * 1024
+        result[key] = value
+    return result
+
+
+def _parse_dmidecode_baseboard(output: str) -> Dict[str, Optional[str]]:
+    vendor = product = serial = None
+    for line in output.splitlines():
+        line = line.strip()
+        if line.startswith("Manufacturer:"):
+            vendor = line.split(":", 1)[1].strip() or None
+        elif line.startswith("Product Name:"):
+            product = line.split(":", 1)[1].strip() or None
+        elif line.startswith("Serial Number:"):
+            serial = line.split(":", 1)[1].strip() or None
+    return {"vendor": vendor, "product": product, "serial": serial}
+
+
+def _parse_dmidecode_bios(output: str) -> Dict[str, Optional[str]]:
+    vendor = version = date = None
+    for line in output.splitlines():
+        line = line.strip()
+        if line.startswith("Vendor:"):
+            vendor = line.split(":", 1)[1].strip() or None
+        elif line.startswith("Version:"):
+            version = line.split(":", 1)[1].strip() or None
+        elif line.startswith("Release Date:"):
+            date = line.split(":", 1)[1].strip() or None
+    return {"bios_vendor": vendor, "bios_version": version, "bios_date": date}
+
+
+def _parse_lspci(output: str) -> List[Dict[str, Optional[str]]]:
+    entries: List[Dict[str, Optional[str]]] = []
+    for line in output.splitlines():
+        if not line.strip():
+            continue
+        parts = shlex.split(line)
+        if len(parts) < 3:
+            continue
+        slot = parts[0]
+        class_name = parts[1].strip('"') if len(parts) > 1 else None
+        vendor = parts[2].strip('"') if len(parts) > 2 else None
+        device = parts[3].strip('"') if len(parts) > 3 else None
+        entries.append(
+            {
+                "slot": slot,
+                "class": class_name,
+                "vendor": vendor,
+                "device": device,
+            }
+        )
+    return entries
+
+
+def _parse_lsusb(output: str) -> List[Dict[str, Optional[str]]]:
+    entries: List[Dict[str, Optional[str]]] = []
+    pattern = re.compile(r"Bus (\d{3}) Device (\d{3}): ID ([0-9a-fA-F]{4}:[0-9a-fA-F]{4}) (.+)")
+    for line in output.splitlines():
+        match = pattern.match(line.strip())
+        if not match:
+            continue
+        bus, dev, ident, rest = match.groups()
+        entries.append(
+            {
+                "bus": bus,
+                "device": dev,
+                "id": ident,
+                "description": rest.strip() or None,
+            }
+        )
+    return entries
+
+
+def _parse_lsblk(output: str) -> List[Dict[str, Any]]:
+    try:
+        data = json.loads(output)
+    except json.JSONDecodeError:
+        return []
+
+    devices = data.get("blockdevices", [])
+
+    def flatten(device: Dict[str, Any]) -> List[Dict[str, Any]]:
+        entries: List[Dict[str, Any]] = []
+        entry = {
+            "name": device.get("name"),
+            "size_bytes": device.get("size"),
+            "rota": device.get("rota"),
+            "tran": device.get("tran"),
+            "model": device.get("model"),
+            "serial": device.get("serial"),
+            "mountpoints": [],
+        }
+        if isinstance(device.get("mountpoints"), list):
+            for mp in device["mountpoints"]:
+                if mp:
+                    entry["mountpoints"].append(mp)
+        if device.get("children"):
+            for child in device["children"]:
+                entries.extend(flatten(child))
+        entries.append(entry)
+        return entries
+
+    all_entries: List[Dict[str, Any]] = []
+    for dev in devices:
+        all_entries.extend(flatten(dev))
+    return all_entries
+
+
+def _parse_dmidecode_slots(output: str) -> List[Dict[str, Any]]:
+    slots: List[Dict[str, Any]] = []
+    current: Dict[str, Any] | None = None
+    for line in output.splitlines():
+        line = line.rstrip()
+        if not line:
+            continue
+        if not line.startswith("\t") and line.strip().startswith("Slot"):  # new section
+            if current:
+                slots.append(current)
+            current = {"slot": line.strip()}
+            continue
+        if current is None:
+            continue
+        stripped = line.strip()
+        if stripped.startswith("Type:"):
+            current["type"] = stripped.split(":", 1)[1].strip() or None
+        elif stripped.startswith("Length:"):
+            length_value = stripped.split(":", 1)[1].strip().lower()
+            if "long" in length_value or "full" in length_value:
+                current["length"] = "full"
+            elif "short" in length_value or "half" in length_value:
+                current["length"] = "short"
+            else:
+                current["length"] = "unknown"
+        elif stripped.startswith("Bus Address:"):
+            current["bus_address"] = stripped.split(":", 1)[1].strip() or None
+        elif stripped.startswith("Current Usage:"):
+            usage = stripped.split(":", 1)[1].strip().lower()
+            current["occupied"] = usage not in {"available", "unavailable"}
+        elif stripped.startswith("Data Bus Width:"):
+            current["lanes"] = stripped.split(":", 1)[1].strip() or None
+        elif stripped.startswith("Designation:"):
+            current["designation"] = stripped.split(":", 1)[1].strip() or None
+        elif stripped.startswith("Installed Device:"):
+            current["device"] = stripped.split(":", 1)[1].strip() or None
+    if current:
+        slots.append(current)
+    return slots
+
+
+def _detect_init_system() -> Optional[str]:
+    comm = pathlib.Path("/proc/1/comm")
+    try:
+        return comm.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+
+
+def _collect_packages(collector: Collector, limit: int = 2000) -> Dict[str, Any]:
+    managers = [
+        ("dpkg", ["dpkg", "-l"]),
+        ("rpm", ["rpm", "-qa"]),
+        ("pacman", ["pacman", "-Q"]),
+    ]
+    for name, argv in managers:
+        if which(argv[0]) is None:
+            continue
+        rc, out, _ = collector.run(f"packages_{name}", argv)
+        if rc != 0 or not out:
+            continue
+        lines = [line.strip() for line in out.splitlines() if line.strip()]
+        if name == "dpkg" and lines:
+            cleaned: List[str] = []
+            for line in lines:
+                if line.startswith("Desired=") or line.startswith("||/") or line.startswith("+++"):
+                    continue
+                cleaned.append(line)
+            items = []
+            for line in cleaned:
+                parts = line.split()
+                if len(parts) >= 3:
+                    items.append(f"{parts[1]} {parts[2]}")
+        else:
+            items = lines
+        truncated = False
+        if len(items) > limit:
+            truncated = True
+            items = items[:limit]
+        return {"manager": name, "items": items, "truncated": truncated}
+    return {"manager": None, "items": [], "truncated": False}
+
+
+def _collect_runtimes(collector: Collector) -> Dict[str, Optional[str]]:
+    runtimes: Dict[str, Optional[str]] = {}
+    commands = {
+        "python": ["python3", "--version"],
+        "python_fallback": ["python", "--version"],
+        "node": ["node", "-v"],
+        "java": ["java", "-version"],
+        "docker": ["docker", "--version"],
+        "podman": ["podman", "--version"],
+    }
+    for key, argv in commands.items():
+        if which(argv[0]) is None:
+            continue
+        rc, out, err = collector.run(key, argv)
+        if rc != 0:
+            continue
+        text = out.strip() or err.strip()
+        if not text:
+            continue
+        logical_key = key.replace("_fallback", "")
+        if logical_key not in runtimes:
+            runtimes[logical_key] = text.splitlines()[0]
+    return runtimes
+
+
+def _detect_tpm() -> bool:
+    sys_path = pathlib.Path("/sys/class/tpm")
+    if sys_path.exists() and any(sys_path.iterdir()):
+        return True
+    rc, out, _ = run_cmd(["dmesg", "--ctime"], timeout=2)
+    if rc == 0 and "tpm" in out.lower():
+        return True
+    return False
+
+
+def _detect_secure_boot() -> str:
+    if which("mokutil") is None:
+        return "unknown"
+    rc, out, _ = run_cmd(["mokutil", "--sb-state"], timeout=2)
+    if rc != 0:
+        return "unknown"
+    text = out.lower()
+    if "enabled" in text:
+        return "enabled"
+    if "disabled" in text:
+        return "disabled"
+    return "unknown"
+
+
+def _extras_collection(collector: Collector, extras: List[str]) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {}
+    for item in extras:
+        if item == "docker" and which("docker") is not None:
+            rc, out, _ = collector.run("docker_ps", ["docker", "ps", "-a", "--format", "{{json .}}"])
+            if rc == 0:
+                payload["docker_containers"] = [line for line in out.splitlines() if line.strip()]
+            rc, out, _ = collector.run("docker_images", ["docker", "images", "--format", "{{json .}}"])
+            if rc == 0:
+                payload["docker_images"] = [line for line in out.splitlines() if line.strip()]
+        elif item == "systemd" and which("systemctl") is not None:
+            rc, out, _ = collector.run("systemctl", ["systemctl", "list-unit-files"])
+            if rc == 0:
+                payload["systemd_unit_files"] = out.splitlines()
+        elif item == "kvm" and which("virsh") is not None:
+            rc, out, _ = collector.run("virsh", ["virsh", "list", "--all"])
+            if rc == 0:
+                payload["kvm_guests"] = out.splitlines()
+    return payload
+
+
+def collect(debug: bool = False, raw_dir: str | None = None, timeout: int = 5) -> Dict[str, Any]:
+    """Collect system information returning a schema compliant document."""
+
+    doc = schema.new_document()
+    collector = Collector(debug, raw_dir, timeout)
+
+    meta = doc["meta"]
+    meta["generated_at"] = now_iso()
+    hostname = socket.gethostname()
+    meta["host"]["hostname"] = hostname
+
+    os_release = _parse_os_release()
+    meta["host"]["os"].update(os_release)
+
+    rc, kernel, _ = collector.run("uname_r", ["uname", "-r"])
+    if rc == 0:
+        meta["host"]["os"]["kernel"] = kernel.strip() or None
+    rc, arch, _ = collector.run("uname_m", ["uname", "-m"])
+    if rc == 0:
+        meta["host"]["os"]["architecture"] = arch.strip() or None
+
+    rc, out, _ = collector.run("lscpu", ["lscpu", "-J"])
+    cpu_data = {}
+    if rc == 0 and out:
+        cpu_data = _parse_lscpu(out)
+    if not cpu_data:
+        rc, out, _ = collector.run("cpuinfo", ["cat", "/proc/cpuinfo"])
+        if rc == 0:
+            cpu_data = _parse_cpuinfo(out)
+    cpu_section = doc["cpu"]
+    if cpu_data:
+        cpu_section["model"] = cpu_data.get("Model name") or cpu_data.get("model name")
+        cpu_section["vendor"] = cpu_data.get("Vendor ID") or cpu_data.get("vendor_id")
+
+        def _int_from(value: Any) -> Optional[int]:
+            if value is None:
+                return None
+            try:
+                return int(str(value).split()[0])
+            except (ValueError, TypeError):
+                return None
+
+        sockets = _int_from(cpu_data.get("Socket(s)"))
+        cores_per_socket = _int_from(cpu_data.get("Core(s) per socket"))
+        threads_per_core = _int_from(cpu_data.get("Thread(s) per core"))
+        logical = _int_from(cpu_data.get("CPU(s)")) or _int_from(cpu_data.get("processor_count"))
+
+        cpu_section["sockets"] = sockets
+        cpu_section["threads_per_core"] = threads_per_core
+        cpu_section["logical_processors"] = logical
+
+        if sockets and cores_per_socket:
+            cpu_section["cores"] = sockets * cores_per_socket
+        else:
+            cpu_section["cores"] = cores_per_socket or logical
+        if "Flags" in cpu_data:
+            cpu_section["flags"] = [flag.strip() for flag in str(cpu_data["Flags"]).split()] if cpu_data["Flags"] else []
+
+    rc, out, _ = collector.run("meminfo", ["cat", "/proc/meminfo"])
+    if rc == 0:
+        meminfo = _parse_meminfo(out)
+        if "MemTotal" in meminfo:
+            doc["memory"]["total_bytes"] = meminfo["MemTotal"]
+        if "SwapTotal" in meminfo:
+            doc["memory"]["swap_bytes"] = meminfo["SwapTotal"]
+
+    rc, out, _ = collector.run("dmidecode_baseboard", ["dmidecode", "-t", "baseboard"])
+    if rc == 0:
+        doc["motherboard"].update(_parse_dmidecode_baseboard(out))
+    rc, out, _ = collector.run("dmidecode_bios", ["dmidecode", "-t", "bios"])
+    if rc == 0:
+        doc["firmware"].update(_parse_dmidecode_bios(out))
+
+    rc, out, _ = collector.run("lspci", ["lspci", "-mm"])
+    if rc == 0:
+        doc["buses"]["pci"] = _parse_lspci(out)
+    rc, out, _ = collector.run("lsusb", ["lsusb"])
+    if rc == 0:
+        doc["buses"]["usb"] = _parse_lsusb(out)
+
+    gpu_entries: List[Dict[str, Any]] = []
+    for entry in doc["buses"]["pci"]:
+        class_name = (entry.get("class") or "").lower()
+        if "vga" in class_name or "3d" in class_name:
+            gpu_entries.append(
+                {
+                    "name": entry.get("device"),
+                    "vendor": entry.get("vendor"),
+                    "bus": entry.get("slot"),
+                }
+            )
+    doc["gpu"] = gpu_entries
+
+    rc, out, _ = collector.run("lsblk", ["lsblk", "-J", "-O"])
+    if rc == 0:
+        doc["storage"] = _parse_lsblk(out)
+
+    # Network information via ip -j address if available
+    if which("ip") is not None:
+        rc, out, _ = collector.run("ip_addr", ["ip", "-j", "address"])
+        if rc == 0:
+            try:
+                entries = json.loads(out)
+            except json.JSONDecodeError:
+                entries = []
+            networks: List[Dict[str, Any]] = []
+            for item in entries:
+                networks.append(
+                    {
+                        "ifname": item.get("ifname"),
+                        "addresses": [addr.get("local") for addr in item.get("addr_info", []) if addr.get("local")],
+                        "mac": item.get("address"),
+                        "state": item.get("operstate"),
+                    }
+                )
+            doc["network"] = networks
+
+    doc["software"]["init"] = _detect_init_system()
+    doc["software"]["packages"] = _collect_packages(collector)
+    doc["software"]["runtimes"] = _collect_runtimes(collector)
+
+    extras_env = os.environ.get("SPEKTOR_EXTRAS", "")
+    extras = [item.strip().lower() for item in extras_env.split(",") if item.strip()]
+    if extras:
+        doc["software"]["extras"] = _extras_collection(collector, extras)
+
+    doc["firmware"]["tpm_present"] = _detect_tpm()
+    doc["firmware"]["secure_boot"] = _detect_secure_boot()
+
+    rc, out, _ = collector.run("dmidecode_slots", ["dmidecode", "-t", "slot"])
+    if rc == 0:
+        doc["slots"]["pcie"] = _parse_dmidecode_slots(out)
+
+    if collector.raw_dir_path is not None:
+        doc.setdefault("debug", {})["artifacts_dir"] = str(collector.raw_dir_path)
+
+    valid, errors = schema.validate(doc)
+    if not valid:
+        doc.setdefault("debug", {})["validation_errors"] = errors
+    return doc

--- a/spektor/util.py
+++ b/spektor/util.py
@@ -1,0 +1,79 @@
+"""Utility helpers for the Spektor project."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+from typing import Iterable, Sequence, Tuple
+
+DEFAULT_TIMEOUT = 5
+
+
+def which(cmd: str | os.PathLike[str]) -> str | None:
+    """Return the path to *cmd* or ``None`` if it cannot be located."""
+
+    return shutil.which(str(cmd))
+
+
+def run_cmd(argv: Sequence[str] | Iterable[str], timeout: int | float | None = None) -> Tuple[int, str, str]:
+    """Run *argv* returning ``(returncode, stdout, stderr)``.
+
+    The command is executed with ``text=True`` so both stdout and stderr are
+    returned as strings.  When the executable is not available a synthetic
+    ``127`` return code is used.
+    """
+
+    if timeout is None:
+        timeout = DEFAULT_TIMEOUT
+
+    try:
+        completed = subprocess.run(
+            list(argv),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+        return completed.returncode, completed.stdout, completed.stderr
+    except FileNotFoundError as exc:  # pragma: no cover - depends on host setup
+        return 127, "", str(exc)
+    except subprocess.TimeoutExpired as exc:
+        return 124, exc.stdout or "", exc.stderr or ""
+
+
+def safe_json_dump(data: object, path: os.PathLike[str] | str, *, indent: int = 2) -> None:
+    """Write *data* to *path* in JSON format creating parents as required."""
+
+    target = pathlib.Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with target.open("w", encoding="utf-8") as fh:
+        json.dump(data, fh, ensure_ascii=False, indent=indent)
+        fh.write("\n")
+
+
+def read_text(path: os.PathLike[str] | str, default: str | None = None) -> str | None:
+    """Return the textual contents of *path* or *default* if it cannot be read."""
+
+    try:
+        return pathlib.Path(path).read_text(encoding="utf-8")
+    except OSError:
+        return default
+
+
+def now_iso() -> str:
+    """Return the current UTC timestamp in ISO-8601 format."""
+
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def sha256_text(text: str) -> str:
+    """Return the hexadecimal SHA-256 digest of *text*."""
+
+    digest = hashlib.sha256()
+    digest.update(text.encode("utf-8"))
+    return digest.hexdigest()

--- a/spektor/version.py
+++ b/spektor/version.py
@@ -1,0 +1,5 @@
+"""Version information for the Spektor package."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/tests/data/lscpu.json
+++ b/tests/data/lscpu.json
@@ -1,0 +1,12 @@
+{
+  "lscpu": [
+    {"field": "Architecture:", "data": "x86_64"},
+    {"field": "Model name:", "data": "Test CPU"},
+    {"field": "Vendor ID:", "data": "GenuineIntel"},
+    {"field": "Socket(s):", "data": "1"},
+    {"field": "Core(s) per socket:", "data": "4"},
+    {"field": "Thread(s) per core:", "data": "2"},
+    {"field": "CPU(s):", "data": "8"},
+    {"field": "Flags:", "data": "fpu sse sse2"}
+  ]
+}

--- a/tests/data/meminfo
+++ b/tests/data/meminfo
@@ -1,0 +1,2 @@
+MemTotal:       16332088 kB
+SwapTotal:       2097148 kB

--- a/tests/data/os-release
+++ b/tests/data/os-release
@@ -1,0 +1,4 @@
+NAME="Debian GNU/Linux"
+VERSION_ID="12"
+ID=debian
+PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,0 +1,33 @@
+import pathlib
+import unittest
+
+from spektor.sysprobe import _parse_lscpu, _parse_meminfo, _parse_os_release
+
+DATA_DIR = pathlib.Path(__file__).parent / "data"
+
+
+class ParserTests(unittest.TestCase):
+    def test_os_release(self):
+        data = _parse_os_release(str(DATA_DIR / "os-release"))
+        self.assertEqual(data["name"], "Debian GNU/Linux")
+        self.assertEqual(data["version"], "12")
+        self.assertEqual(data["id"], "debian")
+        self.assertIn("bookworm", data["pretty_name"])
+
+    def test_lscpu(self):
+        sample = (DATA_DIR / "lscpu.json").read_text(encoding="utf-8")
+        parsed = _parse_lscpu(sample)
+        self.assertEqual(parsed["Model name"], "Test CPU")
+        self.assertEqual(parsed["Vendor ID"], "GenuineIntel")
+        self.assertEqual(parsed["CPU(s)"], "8")
+        self.assertIn("fpu", parsed["Flags"])
+
+    def test_meminfo(self):
+        sample = (DATA_DIR / "meminfo").read_text(encoding="utf-8")
+        parsed = _parse_meminfo(sample)
+        self.assertEqual(parsed["MemTotal"], 16332088 * 1024)
+        self.assertEqual(parsed["SwapTotal"], 2097148 * 1024)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- scaffold the Spektor Python package with schema definitions, Linux collector, Ollama client, reporting helpers, and interactive shell
- add a CLI entry point, packaging metadata, documentation, and GPL licensing for the project
- include parser unit tests, fixtures, and simple Makefile automation for linting and tests

## Testing
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_b_68e00cb8fe18832ca86245f3bddc18ef